### PR TITLE
super-preliminary support for building with gradle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 # generated files
 bin/
 gen/
+.gradle/
+**/build/
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,10 @@
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath 'com.android.tools.build:gradle:0.4'
+  }
+}
+

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'android-library'
+
+android {
+  compileSdkVersion 17
+  buildToolsVersion '17'
+
+  sourceSets {
+    main {
+      manifest.srcFile 'AndroidManifest.xml'
+      java.srcDirs = ['src']
+      res.srcDirs = ['res']
+    }
+  }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'android'
+
+dependencies {
+    compile project(':library')
+    // TODO: we also depend on ActionBarSherlock, which is not in Maven Central as an AAR yet.
+}
+
+android {
+    buildToolsVersion '17.0.0'
+    compileSdkVersion 17
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = ['src']
+            aidl.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+include 'library'
+include 'sample'


### PR DESCRIPTION
This is some preliminary support for building AppMsg with gradle, for use in the [new Android build system](http://tools.android.com/tech-docs/new-build-system/user-guide).

In particular, if [gradle](http://gradle.org/) is on your `PATH` and the Android SDK is set up properly, you can now do `gradle :library:assemble` to build the AppMsg library, and then you can include it in your projects.

Not supported yet:
- building the sample project (because it relies on ActionBarSherlock, which is not yet easily available as an AAR, though support for this is pending, see JakeWharton/ActionBarSherlock#891)
- publishing an AAR of AppMsg itself to Maven Central or something like that

I can work on these two issues (especially the latter) later, but the patch included here is sufficient to let me build my app with AppMsg, so hopefully it will be useful to someone else even in this limited state.
