### PR TITLE
Add missing piece to the build.gradle.

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:0.5.+'
+    }
+}
+
 apply plugin: 'android-library'
 
 android {


### PR DESCRIPTION
Without the dependency on the gradle plugin, the `android-library` is not found.
