### PR TITLE
Update build tools to 19.0.3 (/0.9.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:0.9.1'
     }
 }
 
@@ -17,7 +17,7 @@ allprojects {
     group = GROUP
 
     androidCompileSdk = 19
-    androidToolsVersion = '19'
+    androidToolsVersion = '19.0.3'
     appMsgVersionCode = 4
     appMsgVersionName = VERSION_NAME
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip


### PR DESCRIPTION
Hey @johnkil, just updating the build tools a bit to make it usable with the current Android Studio version (and its surrounding build tools). :-)
